### PR TITLE
minor changes on bs_seeker2-align and bs_seeker2-build

### DIFF
--- a/bs_seeker2-align.py
+++ b/bs_seeker2-align.py
@@ -7,6 +7,7 @@ from bs_align import output
 from bs_align.bs_pair_end import *
 from bs_align.bs_single_end import *
 from bs_align.bs_rrbs import *
+import os
 #import re
 #from bs_utils.utils import *
 
@@ -55,7 +56,10 @@ if __name__ == '__main__':
     opt_group.add_option("-o", "--output", type="string", dest="outfilename",help="The name of output file [INFILE.bs(se|pe|rrbs)]", metavar="OUTFILE")
     opt_group.add_option("-f", "--output-format", type="string", dest="output_format",help="Output format: "+', '.join(output.formats)+" [Default: %default]", metavar="FORMAT", default = output.BAM)
     opt_group.add_option("--no-header", action="store_true", dest="no_SAM_header",help="Suppress SAM header lines [Default: %default]", default = False)
-    opt_group.add_option("--temp_dir", type="string", dest="temp_dir",help="The path to your temporary directory [Detected: %default]", metavar="PATH", default = tempfile.gettempdir())
+    try:
+        opt_group.add_option("--temp_dir", type="string", dest="temp_dir",help="The path to your temporary directory [Detected: %default]", metavar="PATH", default = os.environ["TMPDIR"])
+    except:
+        opt_group.add_option("--temp_dir", type="string", dest="temp_dir",help="The path to your temporary directory [Detected: %default]", metavar="PATH", default = tempfile.gettempdir())
     opt_group.add_option("--XS",type = "string", dest="XS_filter",help="Filter definition for tag XS, format X,Y. X=0.8 and y=5 indicate that for one read, if #(mCH sites)/#(all CH sites)>0.8 and #(mCH sites)>5, then tag XS=1; or else tag XS=0. [Default: %default]", default = "0.5,5") # added by weilong
 
     opt_group.add_option("-M", "--multiple-hit", metavar="FileName", type="string", dest="Output_multiple_hit", default = None, help = 'File to store reads with multiple-hits')

--- a/bs_seeker2-build.py
+++ b/bs_seeker2-build.py
@@ -53,7 +53,11 @@ if __name__ == '__main__':
         error('Fasta file for the reference genome must be supported')
 
     if not os.path.isfile(fasta_file):
-        error('%s cannot be found' % fasta_file)
+        if os.path.isfile(os.path.join(os.dbpath, fasta_file)):
+            # Search for os.dbpath to check if the genome file is stored there.
+            fasta_file = os.path.join(os.dbpath, fasta_file)
+        else:
+            error('%s cannot be found' % fasta_file)
 
     if options.aligner not in supported_aligners:
         error('-a option should be: %s' % ' ,'.join(supported_aligners)+'.')


### PR DESCRIPTION
bs_seeker2-align now can detect environment variable TMPDIR and use it as the temp_dir. 
bs_seeker2-build now supports relative path to genome file if it is put in the reference_genomes folder.
